### PR TITLE
Webgl thread

### DIFF
--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/WebGLThread.cpp
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/WebGLThread.cpp
@@ -1,0 +1,33 @@
+﻿#include <thread>
+
+typedef void (*ThreadStartWithId)(int);
+
+/// <summary>
+/// create and start WebGL thread
+/// </summary>
+/// <param name="start">invoked function</param>
+/// <returns>new thread handle</returns>
+extern "C" std::intptr_t __stdcall UniTaskCreateWebGLThread(ThreadStartWithId start, std::int32_t id)
+{
+    return reinterpret_cast<std::intptr_t>(new std::thread(start, id));
+}
+
+/// <summary>
+/// join WebGL thread
+/// </summary>
+/// <param name="handle">thread handle</param>
+extern "C" void __stdcall UniTaskJoinWebGLThread(std::intptr_t handle)
+{
+    auto thread = reinterpret_cast<std::thread *>(handle);
+    (*thread).join();
+}
+
+/// <summary>
+/// delete WebGL thread
+/// </summary>
+/// <param name="handle">thread handle</param>
+extern "C" void __stdcall UniTaskDeleteWebGLThread(std::intptr_t handle)
+{
+    auto thread = reinterpret_cast<std::thread *>(handle);
+    delete thread;
+}

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/WebGLThread.cpp.meta
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/WebGLThread.cpp.meta
@@ -1,0 +1,69 @@
+fileFormatVersion: 2
+guid: c986c836833b7cf498c2965bee7ce3b4
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude WebGL: 0
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/WebGLThread.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/WebGLThread.cs
@@ -1,0 +1,121 @@
+﻿#if UNITY_WEBGL
+using System;
+using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
+using System.Threading;
+using AOT;
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+    /// <summary>
+    /// Creates and controls a WebGL thread.
+    /// </summary>
+    internal sealed class WebGLThread : IDisposable
+    {
+        private static readonly ConcurrentDictionary<int, WebGLThread> threads = new ConcurrentDictionary<int, WebGLThread>();
+        private static int currentId;
+        private readonly ThreadStart start;
+        private readonly int id;
+
+        /// <summary>
+        /// std::thread pointer
+        /// </summary>
+        private IntPtr handle;
+
+        private delegate void ThreadStartWithId(int id);
+
+        /// <summary>
+        /// Initializes a new instance of the Thread class.
+        /// </summary>
+        /// <param name="start">A ThreadStart delegate that represents the methods to be invoked when this thread begins executing.</param>
+        public WebGLThread(ThreadStart start)
+        {
+            this.id = Interlocked.Increment(ref currentId);
+            this.start = start;
+            threads[this.id] = this;
+            this.ThreadState = ThreadState.Unstarted;
+        }
+
+        /// <summary>
+        /// Gets a value containing the states of the current thread.
+        /// </summary>
+        public ThreadState ThreadState { get; private set; }
+
+        ~WebGLThread()
+        {
+            this.Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Causes the operating system to change the state of the current instance to Running.
+        /// </summary>
+        public void Start()
+        {
+            if (this.ThreadState != ThreadState.Unstarted)
+            {
+                throw new ThreadStateException("Thread is running or terminated. Cannot restart.");
+            }
+
+            this.handle = UniTaskCreateWebGLThread(Execute, this.id);
+        }
+
+        /// <summary>
+        /// Blocks the calling thread until the thread represented by this instance terminates.
+        /// </summary>
+        public void Join()
+        {
+            if (this.ThreadState == ThreadState.Unstarted)
+            {
+                throw new ThreadStateException("Thread is unstarted. Cannot Join.");
+            }
+
+            this.ThreadState = ThreadState.WaitSleepJoin;
+            UniTaskJoinWebGLThread(this.handle);
+        }
+
+        [MonoPInvokeCallback(typeof(ThreadStartWithId))]
+        private static void Execute(int id)
+        {
+            if (!threads.TryRemove(id, out var thread))
+            {
+                return;
+            }
+
+            try
+            {
+                thread.ThreadState = ThreadState.Running;
+                thread.start.Invoke();
+            }
+            finally
+            {
+                thread.ThreadState = ThreadState.Stopped;
+            }
+        }
+
+        private void Dispose(bool disposing)
+        {
+            threads.TryRemove(this.id, out _);
+            if (this.handle != IntPtr.Zero)
+            {
+                UniTaskDeleteWebGLThread(this.handle);
+                this.handle = IntPtr.Zero;
+            }
+        }
+
+        [DllImport("__Internal")]
+        private static extern IntPtr UniTaskCreateWebGLThread(ThreadStartWithId start, int id);
+
+        [DllImport("__Internal")]
+        private static extern void UniTaskJoinWebGLThread(IntPtr handle);
+
+        [DllImport("__Internal")]
+        private static extern void UniTaskDeleteWebGLThread(IntPtr handle);
+    }
+}
+#endif

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/WebGLThread.cs.meta
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/WebGLThread.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9241f404051aba46a933694399141d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/WebGLThreadPool.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/WebGLThreadPool.cs
@@ -54,6 +54,7 @@ namespace Cysharp.Threading.Tasks.Internal
                     if (thread == null)
                     {
                         thread = new WebGLThread(Execute);
+                        thread.Start();
                     }
                 }
             }

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/WebGLThreadPool.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/WebGLThreadPool.cs
@@ -1,4 +1,4 @@
-#if UNITY_WEBGL
+#if UNITY_WEBGL && !UNITY_EDITOR
 #nullable enable
 
 using System;
@@ -8,7 +8,6 @@ using UnityEngine;
 
 namespace Cysharp.Threading.Tasks.Internal
 {
-
     /// <summary>
     /// ThreadPool for WebGL
     /// </summary>

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/WebGLThreadPool.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/WebGLThreadPool.cs
@@ -1,0 +1,98 @@
+#if UNITY_WEBGL
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using UnityEngine;
+
+namespace Cysharp.Threading.Tasks.Internal
+{
+
+    /// <summary>
+    /// ThreadPool for WebGL
+    /// </summary>
+    public static class WebGLThreadPool
+    {
+        private static readonly ConcurrentQueue<(WaitCallback CallBack, object? State)> items = new ConcurrentQueue<(WaitCallback CallBack, object? State)>();
+        private static readonly AutoResetEvent queueItemEvent = new AutoResetEvent(false);
+        private static bool running = true;
+        private static WebGLThread? thread;
+
+        static WebGLThreadPool()
+        {
+            Application.quitting += OnQuitting;
+        }
+
+        /// <summary>
+        /// Queues a method for execution. The method executes when a thread pool thread becomes available.
+        /// </summary>
+        /// <param name="callBack">A <see cref="WaitCallback">WaitCallback</see> that represents the method to be executed.</param>
+        public static void QueueUserWorkItem(WaitCallback callBack)
+        {
+            items.Enqueue((callBack, null));
+            MightStartThread();
+        }
+
+        /// <summary>
+        /// Queues a method for execution. The method executes when a thread pool thread becomes available.
+        /// </summary>
+        /// <param name="callBack">A <see cref="WaitCallback">WaitCallback</see> that represents the method to be executed.</param>
+        /// <param name="state">An object containing data to be used by the method.</param>
+        public static void QueueUserWorkItem(WaitCallback callBack, object state)
+        {
+            items.Enqueue((callBack, state));
+            MightStartThread();
+        }
+
+        private static void MightStartThread()
+        {
+            if (thread == null)
+            {
+                lock (queueItemEvent)
+                {
+                    if (thread == null)
+                    {
+                        thread = new WebGLThread(Execute);
+                    }
+                }
+            }
+
+            queueItemEvent.Set();
+        }
+
+
+        private static void Execute()
+        {
+            while (running)
+            {
+                if (!items.TryDequeue(out var item))
+                {
+                    queueItemEvent.WaitOne();
+                    continue;
+                }
+
+                try
+                {
+                    item.CallBack.Invoke(item.State);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogException(ex);
+                }
+            }
+        }
+
+        private static void OnQuitting()
+        {
+            running = false;
+            queueItemEvent.Set();
+            if (thread != null)
+            {
+                thread.Join();
+                thread.Dispose();
+            }
+        }
+    }
+}
+#endif

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/WebGLThreadPool.cs.meta
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/Internal/WebGLThreadPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e2d52e02fb330540be03562933009f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.Threading.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.Threading.cs
@@ -200,13 +200,19 @@ namespace Cysharp.Threading.Tasks
 
             public void OnCompleted(Action continuation)
             {
+#if UNITY_WEBGL
+                WebGLThreadPool.QueueUserWorkItem(switchToCallback, continuation);
+#else
                 ThreadPool.QueueUserWorkItem(switchToCallback, continuation);
+#endif
             }
 
             public void UnsafeOnCompleted(Action continuation)
             {
 #if NETCOREAPP3_1
                 ThreadPool.UnsafeQueueUserWorkItem(ThreadPoolWorkItem.Create(continuation), false);
+#elif UNITY_WEBGL
+                WebGLThreadPool.QueueUserWorkItem(switchToCallback, continuation);
 #else
                 ThreadPool.UnsafeQueueUserWorkItem(switchToCallback, continuation);
 #endif

--- a/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.Threading.cs
+++ b/src/UniTask/Assets/Plugins/UniTask/Runtime/UniTask.Threading.cs
@@ -200,7 +200,7 @@ namespace Cysharp.Threading.Tasks
 
             public void OnCompleted(Action continuation)
             {
-#if UNITY_WEBGL
+#if UNITY_WEBGL && !UNITY_EDITOR
                 WebGLThreadPool.QueueUserWorkItem(switchToCallback, continuation);
 #else
                 ThreadPool.QueueUserWorkItem(switchToCallback, continuation);
@@ -211,7 +211,7 @@ namespace Cysharp.Threading.Tasks
             {
 #if NETCOREAPP3_1
                 ThreadPool.UnsafeQueueUserWorkItem(ThreadPoolWorkItem.Create(continuation), false);
-#elif UNITY_WEBGL
+#elif UNITY_WEBGL && !UNITY_EDITOR
                 WebGLThreadPool.QueueUserWorkItem(switchToCallback, continuation);
 #else
                 ThreadPool.UnsafeQueueUserWorkItem(switchToCallback, continuation);


### PR DESCRIPTION
## 備考

- 実際に使用する際は `PlayerSettings.WebGL.threadsSupport = true` を設定してビルドを行う必要がある。
  - https://docs.unity3d.com/ScriptReference/PlayerSettings.WebGL-threadsSupport.html
- おそらくアプリを配置したページのヘッダに何らかの設定が必要？
  - https://qiita.com/a-kido/items/8192f7606eab7177d505
  - Editor上で `Build and Run` した際に開いたページ上ではそのまま動いた。
